### PR TITLE
Prevent backscrolls by using `setCommitPage`

### DIFF
--- a/app/page/selectkey.py
+++ b/app/page/selectkey.py
@@ -10,6 +10,11 @@ from .yubikeyitem import YubiKeyItemWidget
 
 
 class SelectYubiKeyPage(QWizardPage):
+    def _prevent_backbutton_clicks(self):
+        # Make sure the user can't navigate back after this step
+        # https://doc.qt.io/qt-5/qwizardpage.html#setCommitPage
+        self.setCommitPage(True)
+
     def __init__(self, mypkcs, parent=None):
         super().__init__(parent)
         self.setTitle("Selecteer de te gebruiken yubikey")
@@ -38,8 +43,9 @@ class SelectYubiKeyPage(QWizardPage):
             self.yubikeyListWidget.setItemWidget(item, itemWidget)
             item.setSizeHint(itemWidget.sizeHint())
 
-        layout.addWidget(self.yubikeyListWidget)
+        self._prevent_backbutton_clicks()
 
+        layout.addWidget(self.yubikeyListWidget)
         self.yubikeyListWidget.currentItemChanged.connect(self.enableNextButton)
 
     def yubiKeySelected(self, current, _previous):

--- a/app/page/selectkey.py
+++ b/app/page/selectkey.py
@@ -11,8 +11,6 @@ from .yubikeyitem import YubiKeyItemWidget
 
 class SelectYubiKeyPage(QWizardPage):
     def _prevent_backbutton_clicks(self):
-        # Make sure the user can't navigate back after this step
-        # https://doc.qt.io/qt-5/qwizardpage.html#setCommitPage
         self.setCommitPage(True)
 
     def __init__(self, mypkcs, parent=None):


### PR DESCRIPTION
This pull request ensures that the user can't navigate backwards after selecting an YubiKey. This is done with the [setCommitPage](https://doc.qt.io/qt-5/qwizardpage.html#setCommitPage) function. This also changes the text from "Next" to "Commit" on that page.