### PR TITLE
No enabling of the next button when the user hasn't selected a YubiKey

### DIFF
--- a/app/page/selectkey.py
+++ b/app/page/selectkey.py
@@ -10,8 +10,8 @@ from .yubikeyitem import YubiKeyItemWidget
 
 
 class SelectYubiKeyPage(QWizardPage):
-    selectedYubiKey: Optional[Any]
-    yubikeyListWidget: QListWidget
+    selected_key: Optional[Any]
+    key_list_widget: QListWidget
 
     def _get_yubikeys(self):
         keys = []
@@ -41,7 +41,7 @@ class SelectYubiKeyPage(QWizardPage):
         super().__init__(parent)
         self.setTitle("Selecteer de te gebruiken yubikey")
 
-        self.selectedYubiKey = None
+        self.selected_key = None
         self.pkcs = mypkcs
         yubikeys = self._get_yubikeys()
         yubikey_list_widget = self._build_yubikey_list_widget(yubikeys)
@@ -50,20 +50,20 @@ class SelectYubiKeyPage(QWizardPage):
         layout.addWidget(yubikey_list_widget)
 
         # Save it for later reference (can this be done better?)
-        self.yubikeyListWidget = yubikey_list_widget
+        self.key_list_widget = yubikey_list_widget
 
     def _find_selected_widget_item(self) -> Optional[YubiKeyItemWidget]:
-        selected_indexes = self.yubikeyListWidget.selectedIndexes()
+        selected_indexes = self.key_list_widget.selectedIndexes()
 
         if selected_indexes == []:
             return None
 
         # Only one should be selected
         first_row = selected_indexes[0].row()
-        selected_item = self.yubikeyListWidget.item(first_row)
+        selected_item = self.key_list_widget.item(first_row)
 
         # Get the widget associated to the selected item
-        widget = self.yubikeyListWidget.itemWidget(selected_item)
+        widget = self.key_list_widget.itemWidget(selected_item)
 
         return widget
 
@@ -74,7 +74,7 @@ class SelectYubiKeyPage(QWizardPage):
             return
 
         # Update the details
-        self.selectedYubiKey = selection.getYubiKeyDetails()
+        self.selected_key = selection.getYubiKeyDetails()
 
         # The next button does not have to be enabled manually, just trigger the completion signal.
         # This will re-check the isCompleted function
@@ -82,14 +82,14 @@ class SelectYubiKeyPage(QWizardPage):
         self.completeChanged.emit()
 
     def isComplete(self) -> bool:
-        return self.selectedYubiKey is not None
+        return self.selected_key is not None
 
     def nextId(self):
         # Store the selected YubiKey information in the wizard
-        self.wizard().setProperty("selectedYubiKey", self.selectedYubiKey)
+        self.wizard().setProperty("selectedYubiKey", self.selected_key)
         return super().nextId()
 
     def initializePage(self) -> None:
         super().initializePage()
 
-        self.yubikeyListWidget.itemSelectionChanged.connect(self.on_yubikey_item_change)
+        self.key_list_widget.itemSelectionChanged.connect(self.on_yubikey_item_change)

--- a/app/page/selectkey.py
+++ b/app/page/selectkey.py
@@ -49,7 +49,6 @@ class SelectYubiKeyPage(QWizardPage):
         layout = QVBoxLayout(self)
         layout.addWidget(yubikey_list_widget)
 
-        # Save it for later reference (can this be done better?)
         self.key_list_widget = yubikey_list_widget
 
     def _find_selected_widget_item(self) -> Optional[YubiKeyItemWidget]:
@@ -70,11 +69,8 @@ class SelectYubiKeyPage(QWizardPage):
     def on_yubikey_item_change(self):
         selection = self._find_selected_widget_item()
 
-        if not selection:
-            return
-
-        # Update the details
-        self.selected_key = selection.getYubiKeyDetails()
+        # Update the details based on if we can find a key
+        self.selected_key = selection.getYubiKeyDetails() if selection else None
 
         # The next button does not have to be enabled manually, just trigger the completion signal.
         # This will re-check the isCompleted function
@@ -93,3 +89,10 @@ class SelectYubiKeyPage(QWizardPage):
         super().initializePage()
 
         self.key_list_widget.itemSelectionChanged.connect(self.on_yubikey_item_change)
+
+    def deselect_all(self):
+        self.key_list_widget.clearSelection()
+        self.selected_key = None
+
+    def cleanupPage(self) -> None:
+        self.deselect_all()

--- a/app/page/selectkey.py
+++ b/app/page/selectkey.py
@@ -1,8 +1,8 @@
+from typing import Any, Optional
 from PyQt6.QtWidgets import (
     QWizardPage,
     QVBoxLayout,
     QListWidget,
-    QWizard,
     QListWidgetItem,
 )
 
@@ -10,51 +10,88 @@ from .yubikeyitem import YubiKeyItemWidget
 
 
 class SelectYubiKeyPage(QWizardPage):
+    selectedYubiKey: Optional[Any]
+    yubikeyListWidget: QListWidget
+
+    def _get_yubikeys(self):
+        keys = []
+        for slot in self.pkcs.pkcs11.getSlotList():
+            try:
+                info = self.pkcs.pkcs11.getTokenInfo(slot)
+                keys += [(info.model, info.serialNumber, info.label, slot)]
+            except Exception:
+                pass
+
+        return keys
+
+    def _build_yubikey_list_widget(self, yubikeys: list[Any]) -> QListWidget:
+        widget = QListWidget()
+        # widget.setSelectionMode(QListWidget.SelectionMode.NoSelection)
+
+        for name, serial, available, slot in yubikeys:
+            itemWidget = YubiKeyItemWidget(name, serial, available, slot)
+            item = QListWidgetItem()
+            item.setSizeHint(itemWidget.sizeHint())
+
+            widget.addItem(item)
+            widget.setItemWidget(item, itemWidget)
+
+        return widget
+
     def __init__(self, mypkcs, parent=None):
         super().__init__(parent)
         self.setTitle("Selecteer de te gebruiken yubikey")
 
         layout = QVBoxLayout(self)
 
-        self.yubikeyListWidget = QListWidget()
-
         self.selectedYubiKey = None
-        self.yubikeyListWidget.currentItemChanged.connect(self.yubiKeySelected)
         self.pkcs = mypkcs
 
-        # Sample YubiKeys
-        yubikeys = []
-        for slot in self.pkcs.pkcs11.getSlotList():
-            try:
-                info = self.pkcs.pkcs11.getTokenInfo(slot)
-                yubikeys += [(info.model, info.serialNumber, info.label, slot)]
-            except Exception:
-                pass
+        yubikeys = self._get_yubikeys()
 
-        for name, serial, available, slot in yubikeys:
-            itemWidget = YubiKeyItemWidget(name, serial, available, slot)
-            item = QListWidgetItem()
-            self.yubikeyListWidget.addItem(item)
-            self.yubikeyListWidget.setItemWidget(item, itemWidget)
-            item.setSizeHint(itemWidget.sizeHint())
+        yubikey_list_widget = self._build_yubikey_list_widget(yubikeys)
+        layout.addWidget(yubikey_list_widget)
 
-        layout.addWidget(self.yubikeyListWidget)
+        # Save it for later reference (can this be done better?)
+        self.yubikeyListWidget = yubikey_list_widget
 
-        self.yubikeyListWidget.currentItemChanged.connect(self.enableNextButton)
+        # yubikey_list_widget.currentItemChanged.connect(self.on_yubikey_row_change)
 
-    def yubiKeySelected(self, current, _previous):
-        if current is not None:
+        # # yubikey_list_widget.currentRowChanged.connect(self.yubiKeySelected)
+        # yubikey_list_widget.itemClicked.connect(self.on_yubikey_row_click)
+
+    def on_yubikey_row_click(self, item: QListWidgetItem):
+        # TODO check here for current selection??? otherwise do nothing
+        # TODO de-select the yubikey on page exit
+        if item is not None:
             # Assuming the YubiKeyItemWidget has a method or property to get the YubiKey details
-            self.selectedYubiKey = self.yubikeyListWidget.itemWidget(current).getYubiKeyDetails()
-            self.wizard().button(QWizard.WizardButton.NextButton).setEnabled(True)
+            self.selectedYubiKey = self.yubikeyListWidget.itemWidget(item).getYubiKeyDetails()
+
+            # The next button does not have to be enabled manually, just trigger the completion signal.
+            # This will re-check the isCompleted function
+            # https://doc.qt.io/qt-6/qwizardpage.html#completeChanged
+            self.completeChanged.emit()
+
+    def on_yubikey_row_change(self, current: QListWidgetItem, previous: Optional[QListWidgetItem]):
+        # TODO check here for current selection??? otherwise select other one
+        item_in_list = self.yubikeyListWidget.itemWidget(current)
+
+        print(1)
+
+    def isComplete(self) -> bool:
+        return self.selectedYubiKey is not None
 
     def nextId(self):
         # Store the selected YubiKey information in the wizard
         self.wizard().setProperty("selectedYubiKey", self.selectedYubiKey)
         return super().nextId()
 
-    def initializePage(self):
-        self.wizard().button(QWizard.WizardButton.NextButton).setEnabled(False)
+    def initializePage(self) -> None:
+        super().initializePage()
 
-    def enableNextButton(self):
-        self.wizard().button(QWizard.WizardButton.NextButton).setEnabled(True)
+        self.yubikeyListWidget.clearSelection()
+
+        self.yubikeyListWidget.currentItemChanged.connect(self.on_yubikey_row_change)
+
+        # yubikey_list_widget.currentRowChanged.connect(self.yubiKeySelected)
+        self.yubikeyListWidget.itemClicked.connect(self.on_yubikey_row_click)


### PR DESCRIPTION
This pull request has been made to fix and clean up the code for YubiKey selection page. Next to that, this is a preparation for [#29](https://github.com/minvws/nl-uzipoc-yubisign/issues/29).  Now, the user can't continue when the key hasn't been selected in the list. Also, when the user navigates back, the item is de-selected. 

While there is a change in naming convention (`_get_yubikeys`, `isComplete`), I do prefer it this way. The overriden functions are from the [QWizardPage](https://doc.qt.io/qt-6/qwizardpage.html) class . 