### PR TITLE
Check PKCS library before starting up the application

### DIFF
--- a/app/bootstrap.py
+++ b/app/bootstrap.py
@@ -69,7 +69,6 @@ class ApplicationBootstrapper:
         return pkcscls
 
     def start(self):
-        load_dotenv()
         app = QApplication(sys.argv)
 
         pkcscls: pkcs = self._load_pkcs_wrapper()

--- a/app/bootstrap.py
+++ b/app/bootstrap.py
@@ -12,7 +12,6 @@ from .pkcs import pkcs
 from .appacme import ACME
 
 import urllib.parse
-from dotenv import load_dotenv
 
 
 from .page.welcome import WelcomePage

--- a/app/main.py
+++ b/app/main.py
@@ -1,5 +1,4 @@
 from os import getenv
-from pathlib import Path
 import sys
 
 from PyQt6.QtWidgets import (

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,97 @@
+from os import getenv
+from pathlib import Path
+import sys
+
+from PyQt6.QtWidgets import (
+    QApplication,
+)
+
+from app.acme_directory_configuration_parser import ACMEDirectoryConfigurationParser
+from app.pkcs_lib_finder import PKCS11LibFinder
+
+from .pkcs import pkcs
+from .appacme import ACME
+
+import urllib.parse
+from dotenv import load_dotenv
+
+
+from .page.welcome import WelcomePage
+from .page.selectkey import SelectYubiKeyPage
+from .page.logindigid import LoginWithDigiDPage
+from .page.creatersakey import CreateRSAKeysPage
+from .page.requestcert import RequestCertificatePage
+from .page.savetoyubi import SaveToYubiKeyPage
+
+
+from PyQt6.QtWidgets import (
+    QSizePolicy,
+    QWizard,
+)
+
+
+class MainWindow(QWizard):
+    def __init__(self, mypkcs, myacme, oidc_provider_base_url: urllib.parse.ParseResult):
+        super().__init__()
+
+        self.setWindowTitle("YubiKey Wizard")
+        self.resize(1024, 768)
+
+        self.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding)
+        self.addPage(WelcomePage())
+        self.addPage(SelectYubiKeyPage(mypkcs))
+        self.addPage(CreateRSAKeysPage(mypkcs))
+        self.addPage(LoginWithDigiDPage(myacme, oidc_provider_base_url))
+        self.addPage(RequestCertificatePage(mypkcs, myacme))
+        self.addPage(SaveToYubiKeyPage(mypkcs))
+
+        # When the wizard has finished, close the application
+        self.finished.connect(QApplication.instance().quit)
+
+
+class ApplicationBootstrapper:
+    PROJECT_ROOT = Path(__file__).parent.parent
+
+    DEFAULT_ACME_CA_SERVER_URL = "https://acme.proeftuin.uzi-online.rdobeheer.nl/directory"
+    DEFAULT_YUBIKEY_PIN = "123456"
+    DEFAULT_PROEFTUIN_OIDC_LOGIN_URL = "https://proeftuin.uzi-online.irealisatie.nl"
+
+    def _load_pkcs_wrapper(self) -> pkcs:
+        yubikey_pin = getenv(
+            "YUBIKEY_PIN",
+        )
+
+        # This will search default locations and fall back to the PYKCS11LIB environment variable
+        pkcslib = PKCS11LibFinder().find()
+
+        if not pkcslib:
+            raise RuntimeError("The PKCS library was not found. Application can't start up.")
+
+        pkcscls = pkcs(pykcs11lib=pkcslib, yubikey_pin=yubikey_pin)
+
+        return pkcscls
+
+    def start(self):
+        load_dotenv()
+        app = QApplication(sys.argv)
+
+        pkcscls: pkcs = self._load_pkcs_wrapper()
+
+        oidc_provider_url = urllib.parse.urlparse(
+            getenv("OIDC_PROVIDER_BASE_URL", self.DEFAULT_PROEFTUIN_OIDC_LOGIN_URL)
+        )
+        print(
+            f'Using OIDC base URL "{oidc_provider_url.geturl()}"',
+        )
+
+        acme_ca_server_url = urllib.parse.urlparse(getenv("ACME_SERVER_DIRECTORY_URL", self.DEFAULT_ACME_CA_SERVER_URL))
+        print(
+            f'Using ACME server directory URL "{acme_ca_server_url.geturl()}"',
+        )
+
+        directory_config = ACMEDirectoryConfigurationParser().parse(acme_ca_server_url)
+        acme = ACME(directory_config)
+
+        mainWindow = MainWindow(pkcscls, acme, oidc_provider_url)
+        mainWindow.show()
+        app.exec()

--- a/app/main.py
+++ b/app/main.py
@@ -65,7 +65,7 @@ class ApplicationBootstrapper:
         pkcslib = PKCS11LibFinder().find()
 
         if not pkcslib:
-            raise RuntimeError("The PKCS library was not found. Application can't start up.")
+            raise RuntimeError("The PKCS library was not found. Application can not start up.")
 
         pkcscls = pkcs(pykcs11lib=pkcslib, yubikey_pin=yubikey_pin)
 

--- a/app/main.py
+++ b/app/main.py
@@ -50,8 +50,6 @@ class MainWindow(QWizard):
 
 
 class ApplicationBootstrapper:
-    PROJECT_ROOT = Path(__file__).parent.parent
-
     DEFAULT_ACME_CA_SERVER_URL = "https://acme.proeftuin.uzi-online.rdobeheer.nl/directory"
     DEFAULT_YUBIKEY_PIN = "123456"
     DEFAULT_PROEFTUIN_OIDC_LOGIN_URL = "https://proeftuin.uzi-online.irealisatie.nl"

--- a/app/wizard.py
+++ b/app/wizard.py
@@ -1,4 +1,4 @@
-from app.main import ApplicationBootstrapper
+from app.bootstrap import ApplicationBootstrapper
 from dotenv import load_dotenv
 
 

--- a/app/wizard.py
+++ b/app/wizard.py
@@ -1,79 +1,8 @@
-from os import getenv
-from pathlib import Path
-import sys
-
-from PyQt6.QtWidgets import (
-    QApplication,
-    QSizePolicy,
-    QWizard,
-)
-
-from app.acme_directory_configuration_parser import ACMEDirectoryConfigurationParser
-from app.pkcs_lib_finder import PKCS11LibFinder
-
-from .pkcs import pkcs
-from .appacme import ACME
-from .page.welcome import WelcomePage
-from .page.selectkey import SelectYubiKeyPage
-from .page.logindigid import LoginWithDigiDPage
-from .page.creatersakey import CreateRSAKeysPage
-from .page.requestcert import RequestCertificatePage
-from .page.savetoyubi import SaveToYubiKeyPage
-
-import urllib.parse
+from app.main import ApplicationBootstrapper
 from dotenv import load_dotenv
-
-PROJECT_ROOT = Path(__file__).parent.parent
-
-DEFAULT_ACME_CA_SERVER_URL = "https://acme.proeftuin.uzi-online.rdobeheer.nl/directory"
-DEFAULT_YUBIKEY_PIN = "123456"
-DEFAULT_PROEFTUIN_OIDC_LOGIN_URL = "https://proeftuin.uzi-online.irealisatie.nl"
-
-
-class MainWindow(QWizard):
-    def __init__(self, mypkcs, myacme, oidc_provider_base_url: urllib.parse.ParseResult):
-        super().__init__()
-
-        self.setWindowTitle("YubiKey Wizard")
-        self.resize(1024, 768)
-
-        self.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding)
-        self.addPage(WelcomePage())
-        self.addPage(SelectYubiKeyPage(mypkcs))
-        self.addPage(CreateRSAKeysPage(mypkcs))
-        self.addPage(LoginWithDigiDPage(myacme, oidc_provider_base_url))
-        self.addPage(RequestCertificatePage(mypkcs, myacme))
-        self.addPage(SaveToYubiKeyPage(mypkcs))
-
-        # When the wizard has finished, close the application
-        self.finished.connect(QApplication.instance().quit)
 
 
 if __name__ == "__main__":
     load_dotenv()
 
-    app = QApplication(sys.argv)
-
-    yubikey_pin = getenv(
-        "YUBIKEY_PIN",
-    )
-    # This will search default locations and fall back to the PYKCS11LIB environment variable
-    pkcslib = PKCS11LibFinder().find()
-    pkcscls = pkcs(pykcs11lib=pkcslib, yubikey_pin=yubikey_pin)
-
-    oidc_provider_url = urllib.parse.urlparse(getenv("OIDC_PROVIDER_BASE_URL", DEFAULT_PROEFTUIN_OIDC_LOGIN_URL))
-    print(
-        f'Using OIDC base URL "{oidc_provider_url.geturl()}"',
-    )
-
-    acme_ca_server_url = urllib.parse.urlparse(getenv("ACME_SERVER_DIRECTORY_URL", DEFAULT_ACME_CA_SERVER_URL))
-    print(
-        f'Using ACME server directory URL "{acme_ca_server_url.geturl()}"',
-    )
-
-    directory_config = ACMEDirectoryConfigurationParser().parse(acme_ca_server_url)
-    acme = ACME(directory_config)
-
-    mainWindow = MainWindow(pkcscls, acme, oidc_provider_url)
-    mainWindow.show()
-    app.exec()
+    ApplicationBootstrapper().start()


### PR DESCRIPTION
This pull request moves the bootstrapping logic into a seperate `ApplicationBootstrapper` class and checks whether the PKCS library was found. 